### PR TITLE
Fix lint-staged configuration in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,4 +4,5 @@
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
+cd gateway
 npx lint-staged


### PR DESCRIPTION
# Summary

- Fix `lint-staged` configuration in `pre-commit` hook.