### PR TITLE
hotfix: install ts-node in auth Dockerfile

### DIFF
--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -6,6 +6,8 @@ COPY package*.json ./
 
 RUN npm install
 
+RUN npm install -g ts-node
+
 COPY . .
 
 EXPOSE 8001


### PR DESCRIPTION
# Summary

- Add `ts-node` as a global dependency in auth `Dockerfile`.